### PR TITLE
Translate remaining Indonesian and Simplified Chinese strings

### DIFF
--- a/translations/id-ID/cmd.config.js
+++ b/translations/id-ID/cmd.config.js
@@ -1,106 +1,106 @@
 module.exports = {
   none: "Tidak ada",
   config: "Konfig",
-  this_channel: "Use Current Channel",
-  updated: "{alert} • Configuration updated. Thank you for using Disping.",
-  limit: "You hit the limit of users you can add using Disping. This limit is in place, so every user can enjoy the same experience using Disping. Thank you for understanding!",
-  404: "User **{username}** cannot be found! Please make sure you entered the {social} username (or handle for YouTube) and not the display name.",
-  invalidURL: "Invalid URL.",
-  saveError: "An error occurred while saving. Please reconfigure the value you were attempting to change. If you continue to get this error, please contact [support]({support}). Sorry for the inconvenience.",
+  this_channel: "Gunakan Kanal Saat Ini",
+  updated: "{alert} • Konfigurasi diperbarui. Terima kasih telah menggunakan Disping.",
+  limit: "Anda telah mencapai batas jumlah pengguna yang dapat ditambahkan menggunakan Disping. Batas ini diterapkan agar setiap pengguna dapat menikmati pengalaman yang sama saat menggunakan Disping. Terima kasih atas pengertiannya!",
+  404: "Pengguna **{username}** tidak dapat ditemukan! Pastikan Anda memasukkan nama pengguna {social} (atau handle untuk YouTube), bukan nama tampilan.",
+  invalidURL: "URL tidak valid.",
+  saveError: "Terjadi kesalahan saat menyimpan. Harap konfigurasikan ulang nilai yang ingin Anda ubah. Jika Anda terus mendapatkan kesalahan ini, silakan hubungi [dukungan]({support}). Maaf atas ketidaknyamanannya.",
   format: {
-    spotify: "Invalid URL. Spotify URLs are normally like this: **https://open.spotify.com/artist/ID_GOES_HERE**.",
-    reddit: "Invalid URL. Reddit URLs are normally like this: **https://www.reddit.com/r/memes**.",
-    threads: "Invalid URL. Thread URLs are normally like this: **https://threads.net/@ch1lldev**"
+    spotify: "URL tidak valid. URL Spotify biasanya seperti ini: **https://open.spotify.com/artist/ID_GOES_HERE**.",
+    reddit: "URL tidak valid. URL Reddit biasanya seperti ini: **https://www.reddit.com/r/memes**.",
+    threads: "URL tidak valid. URL Threads biasanya seperti ini: **https://threads.net/@ch1lldev**"
   },
   loading: {
-    title: "Loading...",
-    desc: "Adding users and configuring Disping to watch them. If you get stuck on this screen, please contact [support]({support}). Thanks for using Disping!"
+    title: "Memuat...",
+    desc: "Menambahkan pengguna dan mengonfigurasi Disping untuk memantau mereka. Jika Anda terjebak di layar ini, silakan hubungi [dukungan]({support}). Terima kasih telah menggunakan Disping!"
   },
   perms: {
-    invalid: "{alert} • You do not have permission (MANAGE_GUILD) to manage this server's settings for Disping. Please contact the server owner to request this permission."
+    invalid: "{alert} • Anda tidak memiliki izin (MANAGE_GUILD) untuk mengelola pengaturan server ini untuk Disping. Silakan hubungi pemilik server untuk meminta izin ini."
   },
   buttons: {
-    saveexit: "Save & Exit",
-    back: "Back",
-    support: "Support",
-    website: "Website",
-    feedback: "Feedback",
-    data: "Export Data"
+    saveexit: "Simpan & Keluar",
+    back: "Kembali",
+    support: "Dukungan",
+    website: "Situs Web",
+    feedback: "Umpan Balik",
+    data: "Ekspor Data"
   },
   colors: {
-    red: "Red",
-    orange: "Orange",
-    yellow: "Yellow",
-    green: "Green",
-    blue: "Blue",
-    purple: "Purple",
-    brown: "Brown",
-    black: "Black",
-    darkgrey: "Dark Grey",
-    white: "White"
+    red: "Merah",
+    orange: "Oranye",
+    yellow: "Kuning",
+    green: "Hijau",
+    blue: "Biru",
+    purple: "Ungu",
+    brown: "Cokelat",
+    black: "Hitam",
+    darkgrey: "Abu-abu Tua",
+    white: "Putih"
   },
   feedback: {
-    name: "Feedback",
-    content: "Content",
-    cooldown: "You've already sent feedback recently! Please wait **{minutes} minutes** and **{seconds} seconds**."
+    name: "Umpan Balik",
+    content: "Isi",
+    cooldown: "Anda baru saja mengirim umpan balik! Mohon tunggu **{minutes} menit** dan **{seconds} detik**."
   },
   socials: {
-    dropdown: "Select the user you would like to manage.",
+    dropdown: "Pilih pengguna yang ingin Anda kelola.",
     state: {
-      true: "Use",
-      false: "Don't Use",
-      show: "Show",
-      hide: "Hide",
-      create: "Create",
-      noCreate: "Don't Create",
-      include: "Include",
-      exclude: "Exclude"
+      true: "Gunakan",
+      false: "Jangan Gunakan",
+      show: "Tampilkan",
+      hide: "Sembunyikan",
+      create: "Buat",
+      noCreate: "Jangan Buat",
+      include: "Sertakan",
+      exclude: "Kecualikan"
     },
     users: {
-      name: "Users",
-      add: "Add User",
-      none: "No users added... click the dropdown menu below and select \"Add User\" to get started!\n\n✨ Remember to save after adding a user.",
-      notify: "Notify",
+      name: "Pengguna",
+      add: "Tambah Pengguna",
+      none: "Belum ada pengguna ditambahkan... klik menu dropdown di bawah lalu pilih \"Tambah Pengguna\" untuk memulai!\n\n✨ Jangan lupa simpan setelah menambahkan pengguna.",
+      notify: "Notifikasi",
       url: "URL",
-      failed: "Configuration Failed"
+      failed: "Konfigurasi Gagal"
     },
     channel: {
-      name: "Channel",
-      desc: "Please select a channel to use from the dropdown below.",
-      placeholder: "Select a channel to use."
+      name: "Kanal",
+      desc: "Silakan pilih kanal yang akan digunakan dari dropdown di bawah.",
+      placeholder: "Pilih kanal untuk digunakan."
     },
     role: {
-      name: "Role",
-      desc: "Please select a role to mention from the dropdown below.",
-      placeholder: "Select a role to use."
+      name: "Peran",
+      desc: "Silakan pilih peran yang akan disebutkan dari dropdown di bawah.",
+      placeholder: "Pilih peran untuk digunakan."
     },
     color: {
-      name: "Color",
-      desc: "Please select a color to show on the embed from the dropdown below.",
-      placeholder: "Select a color to apply to the embed."
+      name: "Warna",
+      desc: "Silakan pilih warna yang akan ditampilkan pada embed dari dropdown di bawah.",
+      placeholder: "Pilih warna untuk diterapkan pada embed."
     },
     message: {
-      name: "Message"
+      name: "Pesan"
     },
     advanced: {
-      embed_editor: "Post Customizer",
-      main: "> Welcome to the post customizer. Tap a button below to enable/disable a part on the embed.",
+      embed_editor: "Kustomisasi Postingan",
+      main: "> Selamat datang di kustomisasi postingan. Tekan tombol di bawah untuk mengaktifkan/menonaktifkan bagian pada embed.",
       embed: "Embed",
-      author: "Author",
+      author: "Penulis",
       thumbnail: "Thumbnail",
-      description: "Description",
-      timestamp: "Timestamp",
-      test: "Send Test Post",
-      event: "Event On Live",
+      description: "Deskripsi",
+      timestamp: "Stempel Waktu",
+      test: "Kirim Postingan Uji Coba",
+      event: "Acara Saat Siaran Langsung",
       crosspost: "Crosspost",
-      retweets: "Retweets",
+      retweets: "Retweet",
       useTFX: "TwitterFX",
       button: {
-        youtube: "Watch Button",
-        twitter: "View Button",
-        twitch: "Watch Button",
-        reddit: "View Button",
-        spotify: "Listen Button"
+        youtube: "Tombol Tonton",
+        twitter: "Tombol Lihat",
+        twitch: "Tombol Tonton",
+        reddit: "Tombol Lihat",
+        spotify: "Tombol Dengarkan"
       }
     }
   }

--- a/translations/id-ID/cmd.help.js
+++ b/translations/id-ID/cmd.help.js
@@ -1,16 +1,16 @@
 module.exports = {
   main: {
-    name: "Daftar",
-    shortDesc: "Kembali ke daftar utama.",
-    desc: "{info} • **About**\n> Start integrating your socials to Discord. The easy way. That's Disping.\n\n**{award} • Credits**\n{allCredits}\n...And all our [\`translators\`](https://cdn.ch1ll.dev/r/translators.png)!\n\n**{robot} • Ch1llDev's Other Bots**\n{allBots}\n\n**{discord} • Join Our Community!**\n> Feel free to join our [\`Discord server\`]({support}) for support, or to talk to the community."
+    name: "Menu",
+    shortDesc: "Kembali ke menu utama.",
+    desc: "{info} • **Tentang**\n> Mulai integrasikan akun sosial Anda ke Discord. Cara yang mudah. Itulah Disping.\n\n**{award} • Kredit**\n{allCredits}\n...Dan semua [\`penerjemah\`](https://cdn.ch1ll.dev/r/translators.png) kami!\n\n**{robot} • Bot Lain Milik Ch1llDev**\n{allBots}\n\n**{discord} • Bergabunglah dengan Komunitas Kami!**\n> Silakan bergabung ke [\`server Discord\`]({support}) kami untuk mendapatkan bantuan, atau ngobrol dengan komunitas."
   },
   feedback: {
-    name: "Feedback",
-    message: "Message"
+    name: "Umpan Balik",
+    message: "Pesan"
   },
   buttons: {
-    invite: "Invite",
-    website: "Website",
-    feedback: "Feedback"
+    invite: "Undang",
+    website: "Situs Web",
+    feedback: "Umpan Balik"
   }
 };

--- a/translations/id-ID/cmd.main.js
+++ b/translations/id-ID/cmd.main.js
@@ -1,7 +1,7 @@
 module.exports = {
   feedback: {
-    name: "Feedback",
-    content: "Content",
-    cooldown: "You've already sent feedback recently! Please wait **{minutes} minutes** and **{seconds} seconds**."
+    name: "Umpan Balik",
+    content: "Isi",
+    cooldown: "Anda baru saja mengirim umpan balik! Mohon tunggu **{minutes} menit** dan **{seconds} detik**."
   }
 };

--- a/translations/id-ID/cmd.support.js
+++ b/translations/id-ID/cmd.support.js
@@ -1,3 +1,3 @@
 module.exports = {
-  reply: "{question} • Need help with Disping? Want to talk to Ch1llDev? Join our [Discord server]({support})!"
+  reply: "{question} • Butuh bantuan dengan Disping? Ingin berbicara dengan Ch1llDev? Bergabunglah ke [server Discord]({support}) kami!"
 };

--- a/translations/zh-CN/cmd.config.js
+++ b/translations/zh-CN/cmd.config.js
@@ -1,31 +1,31 @@
 module.exports = {
-  none: "None",
-  config: "Config",
-  this_channel: "Use Current Channel",
-  updated: "{alert} • 配置已更新。感谢您使用DisPing。",
-  limit: "You hit the limit of users you can add using Disping. This limit is in place, so every user can enjoy the same experience using Disping. Thank you for understanding!",
-  404: "User **{username}** cannot be found! Please make sure you entered the {social} username (or handle for YouTube) and not the display name.",
-  invalidURL: "Invalid URL.",
-  saveError: "An error occurred while saving. Please reconfigure the value you were attempting to change. If you continue to get this error, please contact [support]({support}). Sorry for the inconvenience.",
+  none: "无",
+  config: "配置",
+  this_channel: "使用当前频道",
+  updated: "{alert} • 配置已更新。感谢您使用 Disping。",
+  limit: "你已达到可通过 Disping 添加用户的上限。设置此限制是为了让每位用户都能获得一致的使用体验。感谢理解！",
+  404: "找不到用户 **{username}**！请确认你输入的是 {social} 用户名（YouTube 请输入 handle），而不是显示名称。",
+  invalidURL: "无效的 URL。",
+  saveError: "保存时发生错误。请重新配置你尝试修改的值。如果仍然出现此错误，请联系 [支持]({support})。给你带来不便，敬请谅解。",
   format: {
-    spotify: "Invalid URL. Spotify URLs are normally like this: **https://open.spotify.com/artist/ID_GOES_HERE**.",
-    reddit: "Invalid URL. Reddit URLs are normally like this: **https://www.reddit.com/r/memes**.",
-    threads: "Invalid URL. Thread URLs are normally like this: **https://threads.net/@ch1lldev**"
+    spotify: "无效的 URL。Spotify 链接通常如下：**https://open.spotify.com/artist/ID_GOES_HERE**。",
+    reddit: "无效的 URL。Reddit 链接通常如下：**https://www.reddit.com/r/memes**。",
+    threads: "无效的 URL。Threads 链接通常如下：**https://threads.net/@ch1lldev**"
   },
   loading: {
-    title: "等待一会儿。。。。。。。",
-    desc: "Adding users and configuring Disping to watch them. If you get stuck on this screen, please contact [support]({support}). Thanks for using Disping!"
+    title: "加载中...",
+    desc: "正在添加用户并配置 Disping 以监控他们。如果你长时间停留在此界面，请联系 [支持]({support})。感谢使用 Disping！"
   },
   perms: {
-    invalid: "{alert} • 你没有（MANAGE_GUILD）的资格来配置这个 Guild 的设定。请通知这个 Guild 的主人。"
+    invalid: "{alert} • 你没有权限（MANAGE_GUILD）来管理此服务器的 Disping 设置。请联系服务器所有者申请此权限。"
   },
   buttons: {
-    saveexit: "Save & Exit",
-    back: "Back",
-    support: "Support",
+    saveexit: "保存并退出",
+    back: "返回",
+    support: "支持",
     website: "网站",
-    feedback: "Feedback",
-    data: "Export Data"
+    feedback: "反馈",
+    data: "导出数据"
   },
   colors: {
     red: "红",
@@ -36,71 +36,71 @@ module.exports = {
     purple: "紫",
     brown: "棕",
     black: "黑",
-    darkgrey: "Dark Grey",
+    darkgrey: "深灰",
     white: "白"
   },
   feedback: {
-    name: "Feedback",
-    content: "Content",
-    cooldown: "You've already sent feedback recently! Please wait **{minutes} minutes** and **{seconds} seconds**."
+    name: "反馈",
+    content: "内容",
+    cooldown: "你最近已经发送过反馈了！请等待 **{minutes} 分钟** 和 **{seconds} 秒**。"
   },
   socials: {
-    dropdown: "选你想要使用的 User",
+    dropdown: "请选择你想要管理的用户。",
     state: {
-      true: "Use",
-      false: "Don't Use",
-      show: "Show",
-      hide: "Hide",
-      create: "Create",
-      noCreate: "Don't Create",
-      include: "包括",
+      true: "使用",
+      false: "不使用",
+      show: "显示",
+      hide: "隐藏",
+      create: "创建",
+      noCreate: "不创建",
+      include: "包含",
       exclude: "排除"
     },
     users: {
-      name: "Users",
-      add: "Add User",
-      none: "No users added... click the dropdown menu below and select \"Add User\" to get started!\n\n✨ Remember to save after adding a user.",
-      notify: "Notify",
+      name: "用户",
+      add: "添加用户",
+      none: "尚未添加任何用户... 点击下方下拉菜单并选择\"添加用户\"即可开始！\n\n✨ 添加用户后请记得保存。",
+      notify: "通知",
       url: "URL",
-      failed: "Configuration Failed"
+      failed: "配置失败"
     },
     channel: {
-      name: "Channel",
-      desc: "Please select a channel to use from the dropdown below.",
-      placeholder: "Select a channel to use."
+      name: "频道",
+      desc: "请从下方下拉菜单中选择要使用的频道。",
+      placeholder: "选择要使用的频道。"
     },
     role: {
-      name: "Role",
-      desc: "Please select a role to mention from the dropdown below.",
-      placeholder: "Select a role to use."
+      name: "身份组",
+      desc: "请从下方下拉菜单中选择要提及的身份组。",
+      placeholder: "选择要使用的身份组。"
     },
     color: {
       name: "颜色",
-      desc: "Please select a color to show on the embed from the dropdown below.",
-      placeholder: "请选以下的颜色。"
+      desc: "请从下方下拉菜单中选择在嵌入消息中显示的颜色。",
+      placeholder: "选择要应用到嵌入消息的颜色。"
     },
     message: {
-      name: "Message"
+      name: "消息"
     },
     advanced: {
-      embed_editor: "Post Customizer",
-      main: "> Welcome to the post customizer. Tap a button below to enable/disable a part on the embed.",
-      embed: "Embed",
+      embed_editor: "帖子自定义",
+      main: "> 欢迎使用帖子自定义功能。点击下方按钮可启用/禁用嵌入消息中的某个部分。",
+      embed: "嵌入",
       author: "作者",
-      thumbnail: "Thumbnail",
-      description: "Description",
-      timestamp: "时间",
-      test: "Send Test Post",
-      event: "Event On Live",
-      crosspost: "Crosspost",
-      retweets: "Retweets",
+      thumbnail: "缩略图",
+      description: "描述",
+      timestamp: "时间戳",
+      test: "发送测试帖子",
+      event: "直播时触发",
+      crosspost: "交叉发布",
+      retweets: "转推",
       useTFX: "TwitterFX",
       button: {
         youtube: "观看按钮",
-        twitter: "观看按钮",
+        twitter: "查看按钮",
         twitch: "观看按钮",
-        reddit: "观看按钮",
-        spotify: "Listen Button"
+        reddit: "查看按钮",
+        spotify: "收听按钮"
       }
     }
   }

--- a/translations/zh-CN/cmd.help.js
+++ b/translations/zh-CN/cmd.help.js
@@ -1,16 +1,16 @@
 module.exports = {
   main: {
-    name: "Menu",
-    shortDesc: "Return to the main menu.",
-    desc: "{info} • **About**\n> Start integrating your socials to Discord. The easy way. That's Disping.\n\n**{award} • Credits**\n{allCredits}\n...And all our [\`translators\`](https://cdn.ch1ll.dev/r/translators.png)!\n\n**{robot} • Ch1llDev's Other Bots**\n{allBots}\n\n**{discord} • Join Our Community!**\n> Feel free to join our [\`Discord server\`]({support}) for support, or to talk to the community."
+    name: "菜单",
+    shortDesc: "返回主菜单。",
+    desc: "{info} • **关于**\n> 开始将你的社交账号接入 Discord。简单又高效。这就是 Disping。\n\n**{award} • 致谢**\n{allCredits}\n...以及我们所有的 [\`翻译者\`](https://cdn.ch1ll.dev/r/translators.png)！\n\n**{robot} • Ch1llDev 的其他机器人**\n{allBots}\n\n**{discord} • 加入我们的社区！**\n> 欢迎加入我们的 [\`Discord 服务器\`]({support}) 获取支持，或与社区交流。"
   },
   feedback: {
-    name: "Feedback",
-    message: "Message"
+    name: "反馈",
+    message: "消息"
   },
   buttons: {
-    invite: "Invite",
-    website: "Website",
-    feedback: "Feedback"
+    invite: "邀请",
+    website: "网站",
+    feedback: "反馈"
   }
 };

--- a/translations/zh-CN/cmd.main.js
+++ b/translations/zh-CN/cmd.main.js
@@ -1,7 +1,7 @@
 module.exports = {
   feedback: {
-    name: "Feedback",
-    content: "Content",
-    cooldown: "You've already sent feedback recently! Please wait **{minutes} minutes** and **{seconds} seconds**."
+    name: "反馈",
+    content: "内容",
+    cooldown: "你最近已经发送过反馈了！请等待 **{minutes} 分钟** 和 **{seconds} 秒**。"
   }
 };

--- a/translations/zh-CN/cmd.support.js
+++ b/translations/zh-CN/cmd.support.js
@@ -1,3 +1,3 @@
 module.exports = {
-  reply: "{question} • Need help with Disping? Want to talk to Ch1llDev? Join our [Discord server]({support})!"
+  reply: "{question} • 需要 Disping 的帮助吗？想和 Ch1llDev 聊聊吗？加入我们的 [Discord 服务器]({support}) 吧！"
 };


### PR DESCRIPTION
### Motivation
- Localize remaining English UI strings for the Indonesian (`id-ID`) and Simplified Chinese (`zh-CN`) command files so users see a fully translated experience for `cmd.config`, `cmd.help`, `cmd.main`, and `cmd.support`.
- Preserve placeholders, markdown, and URLs while converting labels, descriptions, error messages, and button text to the target languages.

### Description
- Updated translation strings in `translations/id-ID/cmd.config.js`, `translations/id-ID/cmd.help.js`, `translations/id-ID/cmd.main.js`, and `translations/id-ID/cmd.support.js` to Indonesian.
- Updated translation strings in `translations/zh-CN/cmd.config.js`, `translations/zh-CN/cmd.help.js`, `translations/zh-CN/cmd.main.js`, and `translations/zh-CN/cmd.support.js` to Simplified Chinese.
- Ensured all placeholders (e.g. `{minutes}`, `{seconds}`, `{username}`, `{support}`), Markdown, and example URLs were preserved exactly.
- Kept files valid CommonJS modules so they can be required by the application.

### Testing
- Required each modified file with `node` to validate syntax and module loading, which completed successfully (`ok`).
- Ran a comparison script to report how many strings still match `en-US`, which output `id-ID 7/67` and `zh-CN 2/67` (values indicate remaining identical strings vs total compared).
- Attempted to run `pip install deep-translator` for automated translation assistance but the install failed due to network/proxy restrictions, and this did not block the manual translations or validation steps above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b8d90005c832aba9c9f483a657c8e)